### PR TITLE
Integrate screening client and add Streamlit UI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 urllib3
 pyyaml
+streamlit

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,26 @@
+import streamlit as st
+from agents.tasks import (
+    collect_address,
+    sanction_screen,
+    analyze_results,
+    store_ack,
+    anchor_log,
+)
+
+st.title("Address Sanction Screening")
+address = st.text_input("Wallet address")
+ack = st.checkbox("I declare that I own this address")
+
+if st.button("Submit"):
+    payload = {"address": address, "ack": ack}
+    state = collect_address.run(payload)
+    state = sanction_screen.run(state)
+    state = analyze_results.run(state)
+    state = store_ack.run(state)
+    state = anchor_log.run(state)
+
+    st.subheader("Recommendation")
+    st.write(state.get("analysis", {}).get("decision"))
+
+    st.subheader("Certificate")
+    st.json(state.get("certificate", {}))


### PR DESCRIPTION
## Summary
- Use Legal AI Agents client inside sanction screening task
- Persist user acknowledgements as JSON files for audit
- Provide a simple Streamlit app to submit addresses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac9967332483269d44c66b4160e0ef